### PR TITLE
fix(security): Bump Pillow to >=11.3.0 for HIGH severity CVEs

### DIFF
--- a/archive/web-app/lib/project-templates.ts
+++ b/archive/web-app/lib/project-templates.ts
@@ -1243,7 +1243,7 @@ if __name__ == "__main__":
         path: 'requirements.txt',
         content: `gradio>=4.0.0
 opencv-python>=4.8.0
-Pillow>=10.0.0
+Pillow>=11.3.0
 matplotlib>=3.7.0
 numpy>=1.24.0`,
         isTemplate: false
@@ -1252,7 +1252,7 @@ numpy>=1.24.0`,
     dependencies: {
       'gradio': '>=4.0.0',
       'opencv-python': '>=4.8.0',
-      'Pillow': '>=10.0.0',
+      'Pillow': '>=11.3.0',
       'matplotlib': '>=3.7.0',
       'numpy': '>=1.24.0'
     },

--- a/archive/web-app/lib/templates/index.ts
+++ b/archive/web-app/lib/templates/index.ts
@@ -1040,7 +1040,7 @@ export const PROJECT_TEMPLATES: ProjectTemplate[] = [
     dependencies: {
       'tensorflow': '^2.15.0',
       'opencv-python': '^4.8.0',
-      'pillow': '^10.1.0',
+      'pillow': '^11.3.0',
       'numpy': '^1.24.0',
       'matplotlib': '^3.7.0',
       'scikit-learn': '^1.3.0',

--- a/src/lib/project-templates.ts
+++ b/src/lib/project-templates.ts
@@ -1243,7 +1243,7 @@ if __name__ == "__main__":
         path: 'requirements.txt',
         content: `gradio>=4.0.0
 opencv-python>=4.8.0
-Pillow>=10.0.0
+Pillow>=11.3.0
 matplotlib>=3.7.0
 numpy>=1.24.0`,
         isTemplate: false
@@ -1252,7 +1252,7 @@ numpy>=1.24.0`,
     dependencies: {
       'gradio': '>=4.0.0',
       'opencv-python': '>=4.8.0',
-      'Pillow': '>=10.0.0',
+      'Pillow': '>=11.3.0',
       'matplotlib': '>=3.7.0',
       'numpy': '>=1.24.0'
     },

--- a/src/lib/templates/index.ts
+++ b/src/lib/templates/index.ts
@@ -1040,7 +1040,7 @@ export const PROJECT_TEMPLATES: ProjectTemplate[] = [
     dependencies: {
       'tensorflow': '^2.15.0',
       'opencv-python': '^4.8.0',
-      'pillow': '^10.1.0',
+      'pillow': '^11.3.0',
       'numpy': '^1.24.0',
       'matplotlib': '^3.7.0',
       'scikit-learn': '^1.3.0',


### PR DESCRIPTION
## Summary
- Update Pillow minimum version from 10.x to 11.3.0 in project templates to address HIGH severity heap buffer overflow vulnerabilities

## Security Issues Addressed
- **CVE-2024-28219**: Buffer overflow in `_imagingcms.c` (requires >=10.3.0)
- **CVE-2025-48379**: Heap buffer overflow in DDS encoding (requires >=11.3.0)

## Note on protobuf
The `protobuf==4.25.8` in `docker/agentapi/requirements-skywalking.txt` is already patched for CVE-2025-4565 (unbounded recursion vulnerability) - no update needed.

## Files Changed
- `src/lib/project-templates.ts` - Update Pillow version in template
- `src/lib/templates/index.ts` - Update pillow version in dependencies
- `archive/web-app/lib/project-templates.ts` - Update Pillow version (archive)
- `archive/web-app/lib/templates/index.ts` - Update pillow version (archive)

## Test plan
- [ ] Verify project template generation works with new Pillow version constraint
- [ ] Check that existing projects can install the updated dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)