### PR TITLE
security: remove exposed OpenRouter API key and hardcoded credentials

### DIFF
--- a/services/ai-gateway/.env.example
+++ b/services/ai-gateway/.env.example
@@ -11,6 +11,10 @@ OPENROUTER_TIMEOUT=60000
 OPENROUTER_REFERRER=https://vibecode.dev
 OPENROUTER_TITLE=VibeCode AI Gateway
 
+# Testing Configuration (optional)
+# Set for running E2E tests that require OpenRouter API access
+OPENROUTER_TEST_API_KEY=your_test_api_key_here
+
 # Provider Enablement (comma-separated: azure,openai,hf,openrouter,ollama)
 PROVIDERS_ENABLED=openrouter
 
@@ -80,7 +84,6 @@ DD_API_KEY=
 DATADOG_SITE=us1.datadoghq.com
 DD_ENV=development
 DD_SERVICE=vibecode-ai-gateway
-<<<<<<< HEAD
 
 # Optional: DogStatsD batching for metrics (default: HTTP API)
 # Enable to send metrics via DogStatsD instead of HTTP
@@ -103,5 +106,3 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 OTEL_EXPORTER_OTLP_HEADERS=
 # Sampling rate between 0 and 1 (e.g., 0.1 = 10%)
 TRACE_SAMPLE_RATE=0.1
-=======
->>>>>>> merge-conflict-cleanup

--- a/services/ai-gateway/src/__tests__/openrouter-e2e.int.test.ts
+++ b/services/ai-gateway/src/__tests__/openrouter-e2e.int.test.ts
@@ -129,8 +129,9 @@ jest.mock('../services/datadog-metrics', () => ({
 import express from 'express';
 import request from 'supertest';
 
-// Use test API key if OPENROUTER_API_KEY is not set in environment
-const TEST_API_KEY = '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';
+// Use environment variable for API key - no hardcoded keys for security
+// Set OPENROUTER_API_KEY environment variable before running tests
+const TEST_API_KEY = process.env.OPENROUTER_TEST_API_KEY || 'test-key-placeholder';
 
 async function buildApp() {
   let createApp: (() => express.Express) | undefined;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -97,29 +97,19 @@ export const authOptions: NextAuthOptions = {
       async authorize(credentials) {
         if (!credentials) return null
 
-        // In a real app, you'd look up the user from a database
-        // This is a mock implementation for development
-        const users = [
-          { id: 'legacy-admin', email: 'admin@vibecode.dev', password: 'admin123', name: 'Admin User', role: 'admin' },
-          { id: 'legacy-developer', email: 'developer@vibecode.dev', password: 'dev123', name: 'Developer User', role: 'developer' },
-          { id: 'legacy-lead', email: 'lead@vibecode.dev', password: 'lead123', name: 'Lead User', role: 'lead' },
-          { id: 'legacy-frontend', email: 'frontend@vibecode.dev', password: 'frontend123', name: 'Frontend Developer', role: 'developer' },
-          { id: 'legacy-backend', email: 'backend@vibecode.dev', password: 'backend123', name: 'Backend Developer', role: 'developer' },
-          { id: 'legacy-fullstack', email: 'fullstack@vibecode.dev', password: 'fullstack123', name: 'Fullstack Developer', role: 'developer' },
-          { id: 'legacy-designer', email: 'designer@vibecode.dev', password: 'design123', name: 'Designer', role: 'designer' },
-          { id: 'legacy-tester', email: 'tester@vibecode.dev', password: 'test123', name: 'QA Tester', role: 'tester' },
-          { id: 'legacy-devops', email: 'devops@vibecode.dev', password: 'devops123', name: 'DevOps Engineer', role: 'devops' },
-          { id: 'legacy-intern', email: 'intern@vibecode.dev', password: 'intern123', name: 'Intern', role: 'intern' },
-          { id: 'legacy-security', email: 'security@vibecode.dev', password: 'security123', name: 'Security Engineer', role: 'security' },
-        ]
+        // SECURITY WARNING: This credential provider is disabled for security reasons.
+        // Previously contained hardcoded plaintext passwords which is a critical security vulnerability.
+        //
+        // To enable credential-based authentication:
+        // 1. Set up a proper database with Prisma adapter (uncomment PrismaAdapter above)
+        // 2. Use bcrypt/argon2 for password hashing
+        // 3. Implement proper user registration and password reset flows
+        // 4. Never store plaintext passwords
+        //
+        // For development, use GitHub or Google OAuth providers instead.
 
-        const user = users.find(u => u.email === credentials.email)
-
-        if (user && user.password === credentials.password) {
-          return { id: user.id, name: user.name, email: user.email, role: user.role }
-        } else {
-          return null
-        }
+        logger.warn('Credentials provider called but is disabled for security. Use OAuth providers instead.')
+        return null
       },
     }),
   ],

--- a/tests/__mocks__/@/lib/auth.ts
+++ b/tests/__mocks__/@/lib/auth.ts
@@ -34,30 +34,11 @@ export const authOptions = {
       name: 'Credentials',
       type: 'credentials',
       authorize: async (credentials: Record<string, string>) => {
-        if (!credentials) return null
-
-        // Mock user database for testing
-        const users = [
-          { id: 'legacy-admin', email: 'admin@vibecode.dev', password: 'admin123', name: 'Admin User', role: 'admin' },
-          { id: 'legacy-developer', email: 'developer@vibecode.dev', password: 'dev123', name: 'Developer User', role: 'developer' },
-          { id: 'legacy-lead', email: 'lead@vibecode.dev', password: 'lead123', name: 'Lead User', role: 'lead' },
-          { id: 'legacy-frontend', email: 'frontend@vibecode.dev', password: 'frontend123', name: 'Frontend Developer', role: 'developer' },
-          { id: 'legacy-backend', email: 'backend@vibecode.dev', password: 'backend123', name: 'Backend Developer', role: 'developer' },
-          { id: 'legacy-fullstack', email: 'fullstack@vibecode.dev', password: 'fullstack123', name: 'Fullstack Developer', role: 'developer' },
-          { id: 'legacy-designer', email: 'designer@vibecode.dev', password: 'design123', name: 'Designer', role: 'designer' },
-          { id: 'legacy-tester', email: 'tester@vibecode.dev', password: 'test123', name: 'QA Tester', role: 'tester' },
-          { id: 'legacy-devops', email: 'devops@vibecode.dev', password: 'devops123', name: 'DevOps Engineer', role: 'devops' },
-          { id: 'legacy-intern', email: 'intern@vibecode.dev', password: 'intern123', name: 'Intern', role: 'intern' },
-          { id: 'legacy-security', email: 'security@vibecode.dev', password: 'security123', name: 'Security Engineer', role: 'security' },
-        ]
-
-        const user = users.find(u => u.email === credentials.email)
-
-        if (user && user.password === credentials.password) {
-          return { id: user.id, name: user.name, email: user.email, role: user.role }
-        } else {
-          return null
-        }
+        // SECURITY: Credentials provider disabled in production (see src/lib/auth.ts)
+        // This mock is for testing OAuth flows only - credentials auth returns null
+        // Previously contained legacy plaintext passwords which were removed for security
+        console.warn('Mock credentials provider called - credentials auth is disabled')
+        return null
       },
     },
   ],

--- a/tests/e2e/auth/legacy-credentials.test.ts
+++ b/tests/e2e/auth/legacy-credentials.test.ts
@@ -1,31 +1,16 @@
 import { test, expect, request as playwrightRequest } from '@playwright/test';
 
-const DEFAULT_CREDENTIALS = [
+// SECURITY NOTE: Legacy credentials authentication has been DISABLED
+// These tests verify that credential-based auth properly rejects all attempts
+// Previously tested legacy accounts with plaintext passwords (REMOVED for security)
+const TEST_CREDENTIALS = [
   { email: 'admin@vibecode.dev', password: 'admin123', label: 'Admin' },
-  { email: 'lead@vibecode.dev', password: 'lead123', label: 'Lead' },
   { email: 'developer@vibecode.dev', password: 'dev123', label: 'Developer' },
-  { email: 'frontend@vibecode.dev', password: 'frontend123', label: 'Frontend' },
-  { email: 'backend@vibecode.dev', password: 'backend123', label: 'Backend' },
-  { email: 'fullstack@vibecode.dev', password: 'fullstack123', label: 'Fullstack' },
-  { email: 'designer@vibecode.dev', password: 'design123', label: 'Designer' },
-  { email: 'tester@vibecode.dev', password: 'test123', label: 'Tester' },
-  { email: 'devops@vibecode.dev', password: 'devops123', label: 'DevOps' },
-  { email: 'security@vibecode.dev', password: 'security123', label: 'Security' },
 ];
 
 const baseURL = process.env.LEGACY_AUTH_BASE_URL || process.env.BASE_URL || 'http://localhost:3000';
 
-let credentials = DEFAULT_CREDENTIALS;
-if (process.env.LEGACY_AUTH_CREDENTIALS) {
-  try {
-    const parsed = JSON.parse(process.env.LEGACY_AUTH_CREDENTIALS);
-    if (Array.isArray(parsed)) {
-      credentials = parsed;
-    }
-  } catch (error) {
-    console.warn('Failed to parse LEGACY_AUTH_CREDENTIALS env variable:', error);
-  }
-}
+let credentials = TEST_CREDENTIALS;
 
 // Mock playwright request context for testing
 const mockRequestContext = {
@@ -58,6 +43,8 @@ const mockRequestContext = {
 };
 
 test.describe('Legacy authentication credential smoke (API)', () => {
+  // NOTE: These tests verify credentials auth is properly DISABLED
+  // Credentials provider now returns null for all attempts (security fix)
 
   test('sign-in page responds', async () => {
     try {
@@ -75,7 +62,9 @@ test.describe('Legacy authentication credential smoke (API)', () => {
   });
 
   for (const cred of credentials) {
-    test(`credential flow: ${cred.label}`, async () => {
+    test(`credential flow DISABLED: ${cred.label}`, async () => {
+      // This test verifies that credentials auth is properly disabled
+      // Expected: Should receive 401/403 (unauthorized) or redirect with error
       try {
         const api = await playwrightRequest.newContext({ baseURL });
 
@@ -94,24 +83,15 @@ test.describe('Legacy authentication credential smoke (API)', () => {
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
         });
 
-        expect.soft([200, 302, 400, 401, 403]).toContain(signinResp.status());
+        // Expect auth to fail since credentials provider is disabled
+        expect.soft([400, 401, 403]).toContain(signinResp.status());
 
-        if (signinResp.status() === 200 || signinResp.status() === 302) {
-          const sessionResp = await api.get('/api/auth/session');
-          if (sessionResp.ok()) {
-            const sessionJson = await sessionResp.json().catch(() => undefined);
-            if (sessionJson?.user?.email !== cred.email) {
-              test.info().annotations.push({
-                type: 'warning',
-                description: `Session email mismatch for ${cred.email}`,
-              });
-            }
-          } else {
-            test.info().annotations.push({
-              type: 'warning',
-              description: `Session lookup failed for ${cred.email} (status ${sessionResp.status()})`,
-            });
-          }
+        // Verify no session was created
+        const sessionResp = await api.get('/api/auth/session');
+        if (sessionResp.ok()) {
+          const sessionJson = await sessionResp.json().catch(() => undefined);
+          // Session should NOT contain the credential user
+          expect(sessionJson?.user?.email).not.toBe(cred.email);
         }
       } catch (error) {
         // Use mock if server not available
@@ -121,7 +101,8 @@ test.describe('Legacy authentication credential smoke (API)', () => {
         expect(mockCsrfJson?.csrfToken).toBeTruthy();
 
         const mockSignin = await mockRequestContext.post('/api/auth/signin/credentials', {});
-        expect([200, 302, 400, 401, 403]).toContain(mockSignin.status());
+        // Mock should also reject
+        expect([400, 401, 403]).toContain(mockSignin.status());
       }
     });
   }


### PR DESCRIPTION
## Summary
Fixes critical security vulnerabilities identified in security scan (st-1b5):
- Removed exposed OpenRouter API key from test files
- Removed 11 legacy user accounts with plaintext passwords
- Disabled credentials authentication provider

## Changes
- **services/ai-gateway/src/__tests__/openrouter-e2e.int.test.ts**: Replaced hardcoded API key with `OPENROUTER_TEST_API_KEY` environment variable
- **src/lib/auth.ts**: Removed all hardcoded user credentials, disabled credentials provider
- **tests/__mocks__/@/lib/auth.ts**: Updated mock to match production security fix
- **tests/e2e/auth/legacy-credentials.test.ts**: Updated tests to verify credentials auth is properly disabled
- **services/ai-gateway/.env.example**: Fixed merge conflict, added documentation for test API key

## Security Impact
- ✅ No more exposed API keys in source code
- ✅ No more plaintext passwords in production code
- ✅ Credentials authentication now returns null (disabled)
- ✅ Developers directed to use OAuth (GitHub/Google) instead

## Test Plan
- [x] Verify API key no longer in codebase (grep search)
- [x] Verify plaintext passwords removed
- [x] Update tests to reflect disabled credentials auth
- [x] Document environment variable requirements

Closes st-1b5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled legacy credential-based authentication due to security concerns; plaintext password validation has been removed.

* **Security**
  * Authentication now exclusively uses OAuth providers; credential-based login is no longer available.

* **Chores**
  * Resolved merge conflict markers in test configuration.
  * Updated environment configuration for test API key management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->