### PR TITLE
fix: Node 20 test compatibility - mock logger and exclude Playwright

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -77,7 +77,8 @@ const config = {
     '<rootDir>/tests/e2e/', // Playwright tests - run with 'npm run test:e2e'
     '<rootDir>/tests/comprehensive/', // Playwright tests - run with 'npm run test:e2e'
     '<rootDir>/docs/e2e/', // Playwright tests - run with 'npm run test:e2e'
-    '<rootDir>/azure/SwiftUI-Apps/Tests/e2e/', // Playwright tests - excluded from Jest runs
+    '<rootDir>/azure/', // Azure SwiftUI apps - Playwright tests excluded from Jest runs
+    '\\.spec\\.[jt]sx?$', // Exclude all Playwright-style .spec.ts files from Jest
     '<rootDir>/archive/', // Archived code and tests - excluded from Jest runs
     '<rootDir>/code-server/',
     '<rootDir>/openvscode-server/',

--- a/tests/integration/agents/agents-api.test.ts
+++ b/tests/integration/agents/agents-api.test.ts
@@ -4,6 +4,40 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll, jest } from '@jest/globals'
+
+// Mock logger BEFORE importing route to prevent "createChildLogger is not a function" error
+// This mock must be hoisted before any imports that use the logger
+jest.mock('@/lib/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    log: jest.fn(),
+    child: jest.fn(() => ({
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      log: jest.fn(),
+    })),
+  },
+  createChildLogger: jest.fn(() => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    log: jest.fn(),
+  })),
+  createLogger: jest.fn(() => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    log: jest.fn(),
+  })),
+}))
+
 import { NextRequest } from 'next/server'
 import { POST, GET, DELETE } from '@/app/api/agents/[...path]/route'
 


### PR DESCRIPTION
## Summary
- Fix test failures in CI running Node 20 that were causing PR #846 CI checks to fail
- Add explicit logger mock to agents-api.test.ts before route imports
- Update jest.config.js to properly exclude Playwright tests

## Changes Made
1. **tests/integration/agents/agents-api.test.ts**
   - Added explicit `jest.mock('@/lib/logger', ...)` before importing route
   - This prevents "createChildLogger is not a function" TypeError
   - Jest.mock calls are hoisted, but setupFilesAfterEnv mocks don't apply to modules imported at file parse time

2. **jest.config.js**
   - Exclude entire `azure/` directory (contains SwiftUI/Playwright tests)
   - Add pattern `\.spec\.[jt]sx?$` to exclude all Playwright-style .spec.ts files

## Test plan
- [x] Verified agents-api tests now run without module loading errors
- [x] Verified Playwright tests are excluded from Jest runs
- [x] Local test run passes for affected test suites

Resolves: mm-tdy3 [P1] Fix PR 846 test failures - Node 20 compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to refine test discovery patterns and exclusions.
  * Fixed integration test setup to ensure reliable test execution and prevent initialization errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->