### PR TITLE
feat: Self-Healing CI/CD - Add test retry logic [#885]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,12 @@ jobs:
         run: npm ci --legacy-peer-deps
 
       - name: Run all tests with coverage
-        run: npm run test:coverage
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_on: error
+          command: npm run test:coverage
         env:
           DD_CI_VISIBILITY_ENABLED: true
           DD_API_KEY: ${{ secrets.DD_API_KEY }}


### PR DESCRIPTION
## Summary
- Add nick-fields/retry@v3 to test job
- Max 3 attempts with 15 min timeout per attempt
- Retry only on error (handles flaky tests)

Part of Issue #885 Self-Healing CI/CD Pipeline

Closes #885

## Test plan
- [ ] CI workflow runs successfully
- [ ] Retry logic triggers on test failures

Generated with Claude Code