### PR TITLE
feat: Add Datadog Logging to Deployment Scripts [#768]

### DIFF
--- a/scripts/aks-app-deploy.sh
+++ b/scripts/aks-app-deploy.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 # Deprecated: Application deployment is handled by scripts/app_deploy.py
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/datadog-logging.sh" 2>/dev/null || true
 PYTHON=${PYTHON:-python3}
 
 cat <<'MSG'

--- a/scripts/aks-bootstrap.sh
+++ b/scripts/aks-bootstrap.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 # lives in a single, testable implementation.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/datadog-logging.sh" 2>/dev/null || true
 PYTHON=${PYTHON:-python3}
 
 ENVIRONMENT=${ENVIRONMENT:-dev}

--- a/scripts/bootstrap-from-zero.sh
+++ b/scripts/bootstrap-from-zero.sh
@@ -4,6 +4,11 @@
 
 set -euo pipefail
 
+# Source Datadog logging (optional - doesn't fail if unavailable)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/datadog-logging.sh" 2>/dev/null || true
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'


### PR DESCRIPTION
## Summary
Add Datadog logging integration to key deployment scripts:
- bootstrap-from-zero.sh
- aks-bootstrap.sh
- aks-app-deploy.sh

Uses the existing scripts/lib/datadog-logging.sh library with dd_info, dd_error, dd_metric functions.

Closes #768

## Test plan
- [ ] Scripts still execute without datadog-logging.sh present (graceful fallback)
- [ ] DD logging functions available when library is sourced

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment scripts to include optional logging integration across app deployment, AKS bootstrap, and zero-state bootstrap workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->