### PR TITLE
feat: Bead-Based Agent State Persistence [#898]

### DIFF
--- a/src/lib/beads/schema.ts
+++ b/src/lib/beads/schema.ts
@@ -30,3 +30,105 @@ export interface ConflictResolution {
 }
 
 export type SyncStatus = 'idle' | 'syncing' | 'error';
+
+/**
+ * Agent State Persistence - Issue #898
+ * Bead-based agent state for persistence and recovery
+ */
+
+export interface AgentState {
+  agentId: string;
+  beadId: string;
+  checkpoint: AgentCheckpoint;
+  memorySnapshot: MemorySnapshot;
+  taskQueue: QueuedTask[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface AgentCheckpoint {
+  id: string;
+  agentId: string;
+  version: number;
+  state: Record<string, unknown>;
+  context: AgentContext;
+  timestamp: Date;
+}
+
+export interface AgentContext {
+  conversationId?: string;
+  parentTaskId?: string;
+  capabilities: string[];
+  activeTools: string[];
+  metadata: Record<string, unknown>;
+}
+
+export interface MemorySnapshot {
+  shortTerm: Record<string, unknown>;
+  workingMemory: Record<string, unknown>;
+  persistentKeys: string[];
+  totalSize: number;
+}
+
+export interface QueuedTask {
+  id: string;
+  type: string;
+  priority: number;
+  payload: unknown;
+  createdAt: Date;
+  status: 'pending' | 'processing' | 'completed' | 'failed';
+}
+
+/**
+ * Create a new agent state bead
+ */
+export function createAgentState(agentId: string): AgentState {
+  return {
+    agentId,
+    beadId: `bead-${agentId}-${Date.now()}`,
+    checkpoint: {
+      id: `checkpoint-${Date.now()}`,
+      agentId,
+      version: 1,
+      state: {},
+      context: {
+        capabilities: [],
+        activeTools: [],
+        metadata: {},
+      },
+      timestamp: new Date(),
+    },
+    memorySnapshot: {
+      shortTerm: {},
+      workingMemory: {},
+      persistentKeys: [],
+      totalSize: 0,
+    },
+    taskQueue: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+/**
+ * Create a checkpoint from current agent state
+ */
+export function createCheckpoint(
+  agentId: string,
+  state: Record<string, unknown>,
+  context: Partial<AgentContext> = {}
+): AgentCheckpoint {
+  return {
+    id: `checkpoint-${agentId}-${Date.now()}`,
+    agentId,
+    version: 1,
+    state,
+    context: {
+      capabilities: context.capabilities || [],
+      activeTools: context.activeTools || [],
+      metadata: context.metadata || {},
+      ...context,
+    },
+    timestamp: new Date(),
+  };
+}


### PR DESCRIPTION
## Summary
Extends bead schema with agent state persistence:

- **AgentState**: Full agent state with checkpoint and memory
- **AgentCheckpoint**: Versioned state snapshots for recovery
- **MemorySnapshot**: Short-term and working memory capture
- **QueuedTask**: Task queue for persistence across restarts
- **Helper functions**: createAgentState, createCheckpoint

Closes #898

## Test plan
- [ ] TypeScript compilation passes
- [ ] AgentState creation works correctly
- [ ] Checkpoint versioning increments properly

Generated with Claude Code