### PR TITLE
feat: Infrastructure Modernization - PostgreSQL 17, Valkey 8.1, pgvector [#888]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,9 @@ services:
       - redis
     restart: unless-stopped
 
-  # PostgreSQL Database
+  # PostgreSQL Database with pgvector
   postgres:
-    image: postgres:16
+    image: pgvector/pgvector:pg17
     environment:
       - POSTGRES_DB=vibecode
       - POSTGRES_USER=postgres
@@ -33,9 +33,9 @@ services:
       - "5432:5432"
     restart: unless-stopped
 
-  # Redis for caching and sessions
+  # Valkey for caching and sessions (Redis-compatible)
   redis:
-    image: redis:7-alpine
+    image: valkey/valkey:8.1-alpine
     ports:
       - "6379:6379"
     volumes:


### PR DESCRIPTION
## Summary
Modernizes infrastructure stack:

- **PostgreSQL**: Upgraded to pgvector/pgvector:pg17 (includes pgvector 0.8.x for vector operations)
- **Valkey**: Replaced Redis 7 with Valkey 8.1-alpine (Redis-compatible, truly open source)
- **pgvector**: Built-in with the pgvector image for embedding storage

Closes #888

## Test plan
- [ ] Docker compose up works
- [ ] PostgreSQL 17 connects successfully
- [ ] Valkey accepts Redis commands
- [ ] pgvector extension available

Generated with Claude Code