### PR TITLE
fix: TypeScript strict mode - auth & security logger (#990)

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -51,12 +51,12 @@ function getTestUsers() {
   try {
     const testUsersJson = process.env.AUTH_TEST_USERS;
     if (!testUsersJson) {
-      logger.warn('⚠️ AUTH_TEST_USERS not configured - credentials auth disabled');
+      logger.warn('AUTH_TEST_USERS not configured - credentials auth disabled');
       return [];
     }
     return JSON.parse(testUsersJson);
   } catch (error) {
-    logger.error('❌ Failed to parse AUTH_TEST_USERS:', error);
+    logger.error('Failed to parse AUTH_TEST_USERS:', { error: error instanceof Error ? error.message : String(error) });
     return [];
   }
 }
@@ -85,8 +85,8 @@ declare module 'next-auth' {
 
 declare module 'next-auth/jwt' {
   interface JWT {
-    id: string
-    role: string
+    id?: string | null
+    role?: string | null
     githubId?: string
     googleId?: string
   }
@@ -146,7 +146,7 @@ export const authOptions: NextAuthOptions = {
       },
       async authorize(credentials) {
         if (!credentials?.email || !credentials?.password) {
-          logger.warn('❌ Missing email or password');
+          logger.warn('Missing email or password');
           return null;
         }
 
@@ -157,7 +157,7 @@ export const authOptions: NextAuthOptions = {
         const user = testUsers.find((u: any) => u.email === credentials.email);
 
         if (!user) {
-          logger.warn(`❌ User not found: ${credentials.email}`);
+          logger.warn(`User not found: ${credentials.email}`);
           return null;
         }
 
@@ -166,7 +166,7 @@ export const authOptions: NextAuthOptions = {
           const isValid = await verifyPassword(credentials.password, user.passwordHash);
 
           if (isValid) {
-            logger.info(`✅ Authentication successful: ${user.email}`);
+            logger.info(`Authentication successful: ${user.email}`);
             return {
               id: user.id,
               name: user.name,
@@ -174,11 +174,11 @@ export const authOptions: NextAuthOptions = {
               role: user.role
             };
           } else {
-            logger.warn(`❌ Invalid password for: ${credentials.email}`);
+            logger.warn(`Invalid password for: ${credentials.email}`);
             return null;
           }
         } catch (error) {
-          logger.error('❌ Password verification error:', error);
+          logger.error('Password verification error:', { error: error instanceof Error ? error.message : String(error) });
           return null;
         }
       },
@@ -196,7 +196,7 @@ export const authOptions: NextAuthOptions = {
   },
   callbacks: {
     async jwt({ token, user, account }) {
-      logger.info('🔄 JWT callback:', {
+      logger.info('JWT callback:', {
         hasUser: !!user,
         hasToken: !!token,
         provider: account?.provider,
@@ -215,12 +215,12 @@ export const authOptions: NextAuthOptions = {
         if (account?.provider === 'google') {
           token.googleId = user.googleId
         }
-        logger.info('✅ JWT token updated with user:', { id: token.id, role: token.role })
+        logger.info('JWT token updated with user:', { id: token.id, role: token.role })
       }
       return token
     },
     async session({ session, token }) {
-      logger.info('📋 Session callback:', {
+      logger.info('Session callback:', {
         hasSession: !!session,
         hasToken: !!token,
         tokenId: token?.id,
@@ -228,11 +228,11 @@ export const authOptions: NextAuthOptions = {
       })
 
       if (token) {
-        session.user.id = token.id
-        session.user.role = token.role
-        session.user.email = token.email as string
-        session.user.name = token.name as string
-        logger.info('✅ Session updated with token:', { id: session.user.id, role: session.user.role })
+        session.user.id = (token.id as string) ?? ''
+        session.user.role = (token.role as string) ?? 'user'
+        session.user.email = (token.email as string) ?? ''
+        session.user.name = (token.name as string) ?? ''
+        logger.info('Session updated with token:', { id: session.user.id, role: session.user.role })
       }
       return session
     },

--- a/src/lib/security/logger.ts
+++ b/src/lib/security/logger.ts
@@ -17,39 +17,45 @@ export interface Logger {
   debug(message: string, metadata?: Record<string, unknown>): void
 }
 
-export function console(options: LoggerOptions): Logger {
+// Store reference to global console to avoid shadowing
+const globalConsole = globalThis.console;
+
+export function createLogger(options: LoggerOptions): Logger {
   const prefix = `[${options.module}:${options.scope}]`
 
   return {
     error(message: string, metadata?: Record<string, unknown>) {
       if (metadata) {
-        console.error(prefix, 'ERROR', message, metadata)
+        globalConsole.error(prefix, 'ERROR', message, metadata)
       } else {
-        console.error(prefix, 'ERROR', message)
+        globalConsole.error(prefix, 'ERROR', message)
       }
     },
     warn(message: string, metadata?: Record<string, unknown>) {
       if (metadata) {
-        console.warn(prefix, 'WARN', message, metadata)
+        globalConsole.warn(prefix, 'WARN', message, metadata)
       } else {
-        console.warn(prefix, 'WARN', message)
+        globalConsole.warn(prefix, 'WARN', message)
       }
     },
     info(message: string, metadata?: Record<string, unknown>) {
       if (metadata) {
-        console.info(prefix, 'INFO', message, metadata)
+        globalConsole.info(prefix, 'INFO', message, metadata)
       } else {
-        console.info(prefix, 'INFO', message)
+        globalConsole.info(prefix, 'INFO', message)
       }
     },
     debug(message: string, metadata?: Record<string, unknown>) {
       if (process.env.NODE_ENV === 'development' || process.env.ENABLE_DEBUG_LOGGING === 'true') {
         if (metadata) {
-          console.debug(prefix, 'DEBUG', message, metadata)
+          globalConsole.debug(prefix, 'DEBUG', message, metadata)
         } else {
-          console.debug(prefix, 'DEBUG', message)
+          globalConsole.debug(prefix, 'DEBUG', message)
         }
       }
     },
   }
 }
+
+// Export console as an alias for backward compatibility
+export { createLogger as console };


### PR DESCRIPTION
## Summary
- Resolve TypeScript strict mode errors in `src/lib/auth.ts` (8 errors)
- Resolve TypeScript strict mode errors in `src/lib/security/logger.ts` (8 errors)

### auth.ts fixes:
- Wrap `unknown` error types in proper `Record<string, unknown>` objects for logger calls
- Make JWT interface `id` and `role` properties optional with null union to match base interface
- Add type assertions with nullish coalescing for session user fields

### security/logger.ts fixes:
- Rename function from `console` to `createLogger` to avoid shadowing global `console` object
- Store reference to `globalThis.console` for proper method access
- Export `createLogger` as `console` alias for backward compatibility

## Test plan
- [x] Run `npx tsc --noEmit --strict 2>&1 | grep "src/lib/auth.ts"` - no errors
- [x] Run `npx tsc --noEmit --strict 2>&1 | grep "src/lib/security/logger.ts"` - no errors

Closes #990
Part of #952

Generated with [Claude Code](https://claude.ai/code)