### PR TITLE
fix: TypeScript strict mode - workspace routes (#1006)

### DIFF
--- a/src/app/api/workspace/[id]/init-goose/route.ts
+++ b/src/app/api/workspace/[id]/init-goose/route.ts
@@ -3,6 +3,9 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { exec } from 'child_process';
 import { promisify } from 'util';
+import path from 'path';
+import { validatePathParams, validateRequestBody } from '@/lib/api/validation/middleware';
+import { initGooseParamSchema, initGooseSchema } from '@/lib/api/validation/schemas';
 // import { logger } from '@/lib/logger';
 const execAsync = promisify(exec);
 

--- a/src/app/api/workspaces/route.ts
+++ b/src/app/api/workspaces/route.ts
@@ -6,7 +6,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { WorkspaceProvisioningService } from '@/lib/services/workspace-provisioning-simple'
 import { z } from '@/lib/zod-compat'
-import { createErrorResponse, getErrorMessage, createErrorResponseFromError } from '@/lib/api-utils'
+import { createErrorResponse, getErrorMessage, createErrorResponseFromError, ApiErrors } from '@/lib/api-utils'
 import { logger } from '@/lib/logger';
 const CreateWorkspaceRequestSchema = z.object({
   projectId: z.string(),
@@ -78,9 +78,8 @@ export async function POST(request: NextRequest) {
 
     // Handle validation errors
     if (error instanceof z.ZodError) {
-      return ErrorResponses.validationError(
-        'Invalid request format for workspace creation',
-        error.issues.map(e => `${e.path.join('.')}: ${e.message}`),
+      return ApiErrors.badRequest(
+        `Invalid request format for workspace creation: ${error.issues.map(e => `${e.path.join('.')}: ${e.message}`).join(', ')}`,
         requestId
       )
     }
@@ -88,21 +87,21 @@ export async function POST(request: NextRequest) {
     // Handle Kubernetes errors
     if (error instanceof Error) {
       if (error.message.includes('Unauthorized') || error.message.includes('Forbidden')) {
-        return ErrorResponses.forbidden(
+        return ApiErrors.forbidden(
           'Insufficient permissions to create workspace',
           requestId
         )
       }
 
       if (error.message.includes('timeout')) {
-        return ErrorResponses.badRequest(
+        return ApiErrors.badRequest(
           'Workspace creation timed out. Please try again.',
           requestId
         )
       }
 
       if (error.message.includes('quota') || error.message.includes('resource')) {
-        return ErrorResponses.serviceUnavailable(
+        return ApiErrors.serviceUnavailable(
           'Insufficient cluster resources. Please try again later.',
           requestId
         )
@@ -150,7 +149,7 @@ export async function GET(request: NextRequest) {
 
       if (!workspace) {
         console.warn('Workspace not found', { ...logContext, workspaceId })
-        return ErrorResponses.notFound(
+        return ApiErrors.notFound(
           `Workspace with ID ${workspaceId} not found`,
           requestId
         )


### PR DESCRIPTION
## Summary
- Add missing imports for TypeScript strict mode compliance in workspace routes
- Replace undefined `ErrorResponses` with properly imported `ApiErrors` from `@/lib/api-utils`
- Add missing `path`, `validatePathParams`, `validateRequestBody`, and schema imports to init-goose route

## Files Changed
- `src/app/api/workspaces/route.ts`: Import and use `ApiErrors` instead of undefined `ErrorResponses`
- `src/app/api/workspace/[id]/init-goose/route.ts`: Add missing imports for `path`, validation middleware, and schemas

Closes #1006