### PR TITLE
fix: TypeScript strict mode - lib utilities batch (#1015)

### DIFF
--- a/src/lib/datadog-llm.ts
+++ b/src/lib/datadog-llm.ts
@@ -113,7 +113,7 @@ class LLMObservability {
         }
       });
     } catch (error) {
-      logger.error('Error in LLM workflow span:', error);
+      logger.error('Error in LLM workflow span:', { error: error instanceof Error ? error.message : String(error) });
       return operation(undefined);
     }
   }
@@ -169,7 +169,7 @@ class LLMObservability {
         }
       });
     } catch (error) {
-      logger.error('Error in LLM task span:', error);
+      logger.error('Error in LLM task span:', { error: error instanceof Error ? error.message : String(error) });
       return operation(undefined);
     }
   }
@@ -209,7 +209,7 @@ class LLMObservability {
         });
       }
     } catch (error) {
-      logger.error('Error annotating LLM span:', error);
+      logger.error('Error annotating LLM span:', { error: error instanceof Error ? error.message : String(error) });
     }
   }
 
@@ -230,7 +230,7 @@ class LLMObservability {
         }
       });
     } catch (error) {
-      logger.error('Error flushing LLM observability data:', error);
+      logger.error('Error flushing LLM observability data:', { error: error instanceof Error ? error.message : String(error) });
       return Promise.resolve();
     }
   }

--- a/src/lib/ebpf/integration/datadog-integration.ts
+++ b/src/lib/ebpf/integration/datadog-integration.ts
@@ -289,5 +289,4 @@ export function createDatadogEbpfIntegration(config: EbpfMetricConfig): DatadogE
   return new DatadogEbpfIntegration(config);
 }
 
-// Export types for external use
-export type { VmLifecycleEvent, NetworkEvent, EbpfMetricConfig };
+// Types VmLifecycleEvent, NetworkEvent, and EbpfMetricConfig are exported via their interface declarations above

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -91,20 +91,23 @@ if (!isBuilding && typeof (prisma as any).$use === 'function') {
       return result
     } catch (error) {
       // Record error metrics
+      const errorName = error instanceof Error ? error.name : 'unknown_error'
+      const errorMessage = error instanceof Error ? error.message : String(error)
+
       metrics.increment('db.query.error', {
         service: 'vibecode-webgui',
         operation: params.action,
         model: params.model || 'unknown',
-        error: error?.name || 'unknown_error'
+        error: errorName
       })
-      
+
       if (span) {
         span.setTag('error', true)
-        span.setTag('error.msg', error?.message)
-        span.setTag('error.type', error?.name || 'DatabaseError')
+        span.setTag('error.msg', errorMessage)
+        span.setTag('error.type', errorName)
         span.finish()
       }
-      
+
       throw error
     }
   })

--- a/src/types/datadog-api-client.d.ts
+++ b/src/types/datadog-api-client.d.ts
@@ -1,0 +1,36 @@
+/**
+ * Type declarations for @datadog/api-client-typescript
+ * Provides minimal types for eBPF integration
+ */
+
+declare module '@datadog/api-client-typescript' {
+  export interface DatadogApiConfig {
+    apiKeyAuth: string;
+    site: string;
+  }
+
+  export interface EventCreateRequest {
+    title: string;
+    text: string;
+    tags?: string[];
+    alertType?: string;
+    sourceTypeName?: string;
+  }
+
+  export interface MetricMetadataRequest {
+    metricName: string;
+  }
+
+  export class DatadogApi {
+    constructor(config: DatadogApiConfig);
+
+    v1: {
+      EventsApi: {
+        createEvent(params: { body: EventCreateRequest }): Promise<void>;
+      };
+      MetricsApi: {
+        getMetricMetadata(params: MetricMetadataRequest): Promise<unknown>;
+      };
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Fixes TypeScript strict mode errors in lib utility files for issue #1015:

- **src/lib/datadog-llm.ts** (4 errors): Fixed `unknown` type errors in `logger.error()` calls by properly converting caught errors to `Record<string, unknown>` format using `instanceof Error` checks
- **src/lib/ebpf/integration/datadog-integration.ts** (4 errors): Removed duplicate `export type` declarations that conflicted with existing `export interface` declarations; added type declaration file for `@datadog/api-client-typescript` module
- **src/lib/prisma.ts** (4 errors): Fixed implicit any on error object in catch block by extracting error name and message with proper type guards using `instanceof Error` checks

## Changes

- Add proper error type checking in catch blocks
- Remove duplicate type exports
- Add type declaration for missing Datadog API client module

## Test Plan

- [x] Run `npx tsc --noEmit --strict` - no errors in target files
- [x] All 4 target files now pass TypeScript strict mode

Closes #1015