### PR TITLE
fix: TypeScript strict mode - vector-db batch (#1012)

### DIFF
--- a/src/lib/vector-stores/enhanced-vector-store.ts
+++ b/src/lib/vector-stores/enhanced-vector-store.ts
@@ -3,11 +3,16 @@
  * Advanced vector database operations with intelligent provider selection and optimization
  */
 
-import { VectorChunk, SearchResult, SearchOptions } from '../vector-db/vector-types';
-import { PostgresVectorDatabaseAdapter } from '../vector-db/postgres-vector-database-adapter';
-import { RedisVectorDatabaseAdapter } from '../vector-db/redis-vector-database-adapter';
-import { SqlServerVectorDatabaseAdapter } from '../vector-db/sqlserver-vector-database-adapter';
-import { CosmosDbVectorDatabaseAdapter } from '../vector-db/cosmosdb-vector-database-adapter';
+import { SearchResult, SearchOptions } from '../vector-db/vector-types';
+
+// Export SearchOptions as UnifiedSearchOptions for backward compatibility with sharding extension
+export type UnifiedSearchOptions = SearchOptions;
+// PostgresVectorDatabaseAdapter import available but not yet used in simulated setup
+// import { PostgresVectorDatabaseAdapter } from '../vector-db/postgres-vector-database-adapter';
+// Future adapter imports (modules do not exist yet):
+// import { RedisVectorDatabaseAdapter } from '../vector-db/redis-vector-database-adapter';
+// import { SqlServerVectorDatabaseAdapter } from '../vector-db/sqlserver-vector-database-adapter';
+// import { CosmosDbVectorDatabaseAdapter } from '../vector-db/cosmosdb-vector-database-adapter';
 
 export interface VectorStoreConfig {
   primaryProvider: 'postgres' | 'redis' | 'sqlserver' | 'cosmosdb';
@@ -35,6 +40,8 @@ export interface SearchContext {
   searchIntent?: 'semantic' | 'hybrid' | 'keyword' | 'generative';
   complexity?: 'simple' | 'moderate' | 'complex';
   urgency?: 'low' | 'normal' | 'high';
+  /** Internal: used for fallback provider routing */
+  _useProvider?: string;
 }
 
 /**
@@ -362,7 +369,7 @@ export class EnhancedVectorStore {
    * Search with fallback provider on failure
    */
   private async searchWithFallback(
-    query: string | number[],
+    query: string,
     options: SearchOptions,
     context: SearchContext,
     failedProvider: string


### PR DESCRIPTION
## Summary
- Comment out missing adapter imports (redis, sqlserver, cosmosdb) in `src/lib/vector-stores/enhanced-vector-store.ts`
- Add `UnifiedSearchOptions` type alias for backward compatibility with sharding extension
- Add `_useProvider` to `SearchContext` interface for fallback provider routing
- Fix `searchWithFallback` parameter type from `string | number[]` to `string` to match calling signature

Closes #1012

## Test plan
- [x] Run `npx tsc --noEmit --strict` to verify no TypeScript errors in the three target files
- [x] Verify the sharding extension still compiles with the new `UnifiedSearchOptions` export

Generated with Claude Code