### PR TITLE
fix: TypeScript strict mode - components batch 1 (#1026)

### DIFF
--- a/src/components/chat/HuggingFaceChatInterface.tsx
+++ b/src/components/chat/HuggingFaceChatInterface.tsx
@@ -633,7 +633,7 @@ export const HuggingFaceChatInterface = ({
                   }}
                   className="text-amber-700 border-amber-300 hover:bg-amber-100"
                 >
-                  Switch to {availableModels.concat(huggingFaceModels).find(m => m.id === lastModelSuggestion.suggested)?.name || lastModelSuggestion.suggested}
+                  Switch to {[...availableModels, ...huggingFaceModels].find(m => m.id === lastModelSuggestion.suggested)?.name || lastModelSuggestion.suggested}
                 </Button>
                 <Button
                   variant="ghost"

--- a/src/components/marketplace/TemplateSubmissionForm.tsx
+++ b/src/components/marketplace/TemplateSubmissionForm.tsx
@@ -66,8 +66,8 @@ const templateFormSchema = z.object({
   framework: z.string().trim().min(2, 'Select a framework'),
   complexity: z.enum(['beginner', 'intermediate', 'advanced']),
   tags: z.array(z.string().trim().min(1)).max(20).default([]),
-  dependencies: z.record(z.string().trim().min(1)).default({}),
-  scripts: z.record(z.string().trim().min(1)).default({}),
+  dependencies: z.record(z.string(), z.string().trim().min(1)).default({}),
+  scripts: z.record(z.string(), z.string().trim().min(1)).default({}),
   envVars: z
     .array(
       z.object({
@@ -216,7 +216,7 @@ export function TemplateSubmissionForm({
     });
 
     try {
-      await onSubmit?.(validation.data);
+      await onSubmit?.(validation.data as TemplateFormData);
 
       setSubmissionStatus({
         status: 'success',

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils"
 
 interface TooltipProps {
   children: React.ReactNode
-  content: string
+  content?: string
   className?: string
 }
 

--- a/src/design-system/components/MultiAgentWorkspace.tsx
+++ b/src/design-system/components/MultiAgentWorkspace.tsx
@@ -250,7 +250,7 @@ function TabletWorkspace({
   };
 
   return (
-    <PanelGroup direction="horizontal" className="h-screen">
+    <PanelGroup orientation="horizontal" className="h-screen">
       {/* Agent sidebar */}
       <Panel defaultSize={20} minSize={15} maxSize={30}>
         <div className="h-full bg-white dark:bg-neutral-900 border-r border-neutral-200 dark:border-neutral-700">
@@ -272,7 +272,7 @@ function TabletWorkspace({
                     'bg-neutral-100 dark:bg-neutral-800 ring-2 ring-inset'
                 )}
                 style={{
-                  ringColor: selectedAgent.id === agent.id ? agent.color : undefined,
+                  ['--tw-ring-color' as string]: selectedAgent.id === agent.id ? agent.color : undefined,
                 }}
               >
                 <div
@@ -403,7 +403,7 @@ function DesktopWorkspace({
               )}
               style={{
                 backgroundColor: agent.bgColor,
-                ringColor: isActive ? agent.color : undefined,
+                ['--tw-ring-color' as string]: isActive ? agent.color : undefined,
               }}
               title={agent.name}
               aria-label={`${isActive ? 'Remove' : 'Add'} ${agent.name}`}

--- a/src/types/lucide-react.d.ts
+++ b/src/types/lucide-react.d.ts
@@ -91,6 +91,10 @@ declare module 'lucide-react' {
   export const Heart: LucideIcon
   export const Bookmark: LucideIcon
   export const Share: LucideIcon
+  export const Share2: LucideIcon
+  export const QrCode: LucideIcon
+  export const AlertTriangle: LucideIcon
+  export const GripVertical: LucideIcon
   export const Link: LucideIcon
   export const ExternalLink: LucideIcon
   export const Mail: LucideIcon


### PR DESCRIPTION
## Summary
- Fix z.record() to use two arguments (key and value types) for Zod v4 compatibility in TemplateSubmissionForm.tsx
- Change PanelGroup `direction` prop to `orientation` for react-resizable-panels compatibility in MultiAgentWorkspace.tsx
- Replace invalid `ringColor` CSS property with `--tw-ring-color` CSS variable in MultiAgentWorkspace.tsx
- Fix array concat type mismatch by using spread operator in HuggingFaceChatInterface.tsx
- Make Tooltip `content` prop optional to support Radix-style API in tooltip.tsx
- Add missing lucide-react icon type declarations (Share2, QrCode, AlertTriangle, GripVertical)

## Test plan
- [x] Run `npx tsc --noEmit --strict` and verify no errors in target files
- [x] Verify all 12 TypeScript strict mode errors are resolved

Fixes #1026

Generated with Claude Code