### PR TITLE
fix: TypeScript strict mode - lib modules batch (#1034)

### DIFF
--- a/src/lib/monitoring/monitoring-dashboard.ts
+++ b/src/lib/monitoring/monitoring-dashboard.ts
@@ -532,5 +532,3 @@ class MonitoringDashboardService {
 // Export singleton instance
 export const monitoringDashboard = new MonitoringDashboardService()
 
-// Export types
-export type { DashboardWidget, MonitoringDashboard }

--- a/src/lib/multimodal-agent.ts
+++ b/src/lib/multimodal-agent.ts
@@ -264,7 +264,7 @@ export class MultimodalAgent {
 
     } catch (error) {
       this.logAgentActivity('multimodal_processing_error', {
-        error: error.message,
+        error: error instanceof Error ? error.message : String(error),
         processingTime: Date.now() - startTime
       });
       
@@ -707,13 +707,13 @@ Be encouraging, technically accurate, and provide working code examples.`;
    * Calculate cost based on tokens and model
    */
   private calculateCost(tokens: number, model: string): number {
-    const costs = {
+    const costs: Record<string, number> = {
       'anthropic/claude-3.5-sonnet': 0.015 / 1000,
       'anthropic/claude-3-haiku': 0.0025 / 1000,
       'openai/gpt-4o-mini': 0.0015 / 1000
     };
 
-    return tokens * (costs[model] || 0.01 / 1000);
+    return tokens * (costs[model] ?? 0.01 / 1000);
   }
 
   /**

--- a/src/lib/protocols/adapters/base-adapter.ts
+++ b/src/lib/protocols/adapters/base-adapter.ts
@@ -113,14 +113,17 @@ export abstract class BaseAgentAdapter {
 // Adapter Registry
 // ============================================================================
 
-export class AgentAdapterRegistry {
-  private static adapters = new Map<AgentAdapterType, typeof BaseAgentAdapter>();
+// Type for concrete adapter class constructors (not abstract)
+type ConcreteAdapterClass = new (config: AgentConfig) => BaseAgentAdapter;
 
-  static register(type: AgentAdapterType, adapter: typeof BaseAgentAdapter): void {
+export class AgentAdapterRegistry {
+  private static adapters = new Map<AgentAdapterType, ConcreteAdapterClass>();
+
+  static register(type: AgentAdapterType, adapter: ConcreteAdapterClass): void {
     this.adapters.set(type, adapter);
   }
 
-  static get(type: AgentAdapterType): typeof BaseAgentAdapter | undefined {
+  static get(type: AgentAdapterType): ConcreteAdapterClass | undefined {
     return this.adapters.get(type);
   }
 

--- a/src/lib/protocols/adapters/goose-adapter.ts
+++ b/src/lib/protocols/adapters/goose-adapter.ts
@@ -13,7 +13,7 @@ import type { MCPClient } from '../mcp-client';
 export class GooseAdapter extends BaseAgentAdapter {
   private agentId: string | null = null;
   private eventSource: EventSource | null = null;
-  private mcpClient: MCPClient | null = null;
+  protected override mcpClient: MCPClient | null = null;
 
   constructor(config: AgentConfig) {
     super(config);

--- a/src/lib/protocols/adapters/universal-adapter.ts
+++ b/src/lib/protocols/adapters/universal-adapter.ts
@@ -13,7 +13,7 @@ import type { MCPClient } from '../mcp-client';
 export class UniversalAdapter extends BaseAgentAdapter {
   private protocol: 'agentapi' | 'mcp' | null = null;
   private agentId: string | null = null;
-  private mcpClient: MCPClient | null = null;
+  protected override mcpClient: MCPClient | null = null;
   private eventSource: EventSource | null = null;
 
   constructor(config: AgentConfig) {

--- a/src/lib/rag/index.ts
+++ b/src/lib/rag/index.ts
@@ -249,4 +249,4 @@ export const ragSystem = new RAGSystem();
 
 // Re-export for convenience
 export { vectorStore, valkeyCache, embeddingService };
-export type { SearchResult, RAGDocument, RAGSearchOptions };
+export type { SearchResult };


### PR DESCRIPTION
## Summary
- Fixes TypeScript strict mode errors in lib modules batch for issue #1034
- Removes duplicate type exports in `src/lib/rag/index.ts` and `src/lib/monitoring/monitoring-dashboard.ts`
- Fixes abstract class instantiation in `src/lib/protocols/adapters/base-adapter.ts` by using a concrete class type
- Resolves property override issues in GooseAdapter and UniversalAdapter
- Fixes unknown error type handling and adds proper Record type in `src/lib/multimodal-agent.ts`

## Files Changed
- `src/lib/rag/index.ts` - Remove duplicate type exports for RAGDocument and RAGSearchOptions
- `src/lib/protocols/adapters/base-adapter.ts` - Add ConcreteAdapterClass type for non-abstract class instantiation
- `src/lib/protocols/adapters/goose-adapter.ts` - Use protected override for mcpClient property
- `src/lib/protocols/adapters/universal-adapter.ts` - Use protected override for mcpClient property
- `src/lib/monitoring/monitoring-dashboard.ts` - Remove duplicate type exports
- `src/lib/multimodal-agent.ts` - Fix unknown error type and add Record<string, number> type

Fixes #1034

## Test plan
- [x] Run `npx tsc --noEmit --strict` and verify no errors in target files
- [x] Verify all type exports are properly resolved

Generated with Claude Code