### PR TITLE
fix: TypeScript strict mode - enhanced datadog integration (#1052)

### DIFF
--- a/src/lib/monitoring/enhanced-datadog-integration.ts
+++ b/src/lib/monitoring/enhanced-datadog-integration.ts
@@ -120,8 +120,8 @@ export class EnhancedDatadogMonitoring {
       'terminal_type:enhanced-ai'
     ];
     
-    statsd.increment('terminal.sessions.created', 1, sessionTags);
-    statsd.gauge('terminal.sessions.active', this.terminalSessionMetrics.size, sessionTags);
+    statsd.increment('terminal.sessions.created', 1, 1, sessionTags);
+    statsd.gauge('terminal.sessions.active', this.terminalSessionMetrics.size, 1, sessionTags);
 
     span.finish()
   }
@@ -148,8 +148,8 @@ export class EnhancedDatadogMonitoring {
       `session:${sessionId}`
     ];
     
-    statsd.increment('terminal.commands.executed', 1, commandTags);
-    statsd.histogram('terminal.command.execution_time', executionTime, commandTags);
+    statsd.increment('terminal.commands.executed', 1, 1, commandTags);
+    statsd.histogram('terminal.command.execution_time', executionTime, 1, commandTags);
 
     span.finish()
   }
@@ -185,11 +185,11 @@ export class EnhancedDatadogMonitoring {
     ];
 
     // Send metrics with string array tags
-    statsd.increment('ai.requests', 1, aiTags);
-    statsd.histogram('ai.response_time', responseTime, aiTags);
+    statsd.increment('ai.requests', 1, 1, aiTags);
+    statsd.histogram('ai.response_time', responseTime, 1, aiTags);
 
     if (tokenUsage) {
-      statsd.histogram('ai.tokens_used', tokenUsage, aiTags);
+      statsd.histogram('ai.tokens_used', tokenUsage, 1, aiTags);
     }
 
     span.finish()
@@ -218,8 +218,8 @@ export class EnhancedDatadogMonitoring {
     ];
     
     // Send metrics with string array tags
-    statsd.increment('claude.cli.commands', 1, cliTags);
-    statsd.histogram('claude.cli.response_time', responseTime, cliTags);
+    statsd.increment('claude.cli.commands', 1, 1, cliTags);
+    statsd.histogram('claude.cli.response_time', responseTime, 1, cliTags);
 
     span.finish()
   }
@@ -243,13 +243,13 @@ export class EnhancedDatadogMonitoring {
     const modelTag = `model:${model}`;
     
     // Send metrics with string array tags
-    statsd.increment('openrouter.requests', 1, [modelTag]);
-    statsd.histogram('openrouter.response_time', responseTime, [modelTag]);
-    statsd.histogram('openrouter.prompt_tokens', promptTokens, [modelTag]);
-    statsd.histogram('openrouter.completion_tokens', completionTokens, [modelTag]);
+    statsd.increment('openrouter.requests', 1, 1, [modelTag]);
+    statsd.histogram('openrouter.response_time', responseTime, 1, [modelTag]);
+    statsd.histogram('openrouter.prompt_tokens', promptTokens, 1, [modelTag]);
+    statsd.histogram('openrouter.completion_tokens', completionTokens, 1, [modelTag]);
 
     if (cost) {
-      statsd.histogram('openrouter.cost', cost, [modelTag]);
+      statsd.histogram('openrouter.cost', cost, 1, [modelTag]);
     }
 
     span.finish()
@@ -284,15 +284,15 @@ export class EnhancedDatadogMonitoring {
       );
 
       // Send metrics with string array tags
-      statsd.histogram('terminal.session.duration', sessionDuration, sessionEndTags);
-      statsd.histogram('terminal.session.commands', session.commandCount, sessionEndTags);
-      statsd.histogram('terminal.session.ai_usage', session.aiUsageCount, sessionEndTags);
+      statsd.histogram('terminal.session.duration', sessionDuration, 1, sessionEndTags);
+      statsd.histogram('terminal.session.commands', session.commandCount, 1, sessionEndTags);
+      statsd.histogram('terminal.session.ai_usage', session.aiUsageCount, 1, sessionEndTags);
 
       this.terminalSessionMetrics.delete(sessionId)
     }
 
     // Update active sessions gauge with the same end_reason tag
-    statsd.gauge('terminal.sessions.active', this.terminalSessionMetrics.size, sessionEndTags)
+    statsd.gauge('terminal.sessions.active', this.terminalSessionMetrics.size, 1, sessionEndTags)
 
     span.finish()
   }
@@ -318,7 +318,7 @@ export class EnhancedDatadogMonitoring {
     ];
     
     // Send metrics with string array tags
-    statsd.increment('workspace.activities', 1, workspaceTags)
+    statsd.increment('workspace.activities', 1, 1, workspaceTags)
 
     span.finish()
   }
@@ -348,10 +348,10 @@ export class EnhancedDatadogMonitoring {
     ];
     
     // Send metrics with string array tags
-    statsd.increment('ai.suggestions', 1, suggestionTags);
+    statsd.increment('ai.suggestions', 1, 1, suggestionTags);
 
     if (helpfulness !== undefined) {
-      statsd.histogram('ai.suggestion.helpfulness', helpfulness, [
+      statsd.histogram('ai.suggestion.helpfulness', helpfulness, 1, [
         `trigger:${trigger}`
       ]);
     }
@@ -370,17 +370,17 @@ export class EnhancedDatadogMonitoring {
     const systemTags = ['source:node_process'];
 
     // Memory metrics
-    statsd.gauge('system.memory.used', memUsage.heapUsed, systemTags)
-    statsd.gauge('system.memory.total', memUsage.heapTotal, systemTags)
-    statsd.gauge('system.memory.external', memUsage.external, systemTags)
+    statsd.gauge('system.memory.used', memUsage.heapUsed, 1, systemTags)
+    statsd.gauge('system.memory.total', memUsage.heapTotal, 1, systemTags)
+    statsd.gauge('system.memory.external', memUsage.external, 1, systemTags)
 
     // CPU metrics
-    statsd.gauge('system.cpu.user', cpuUsage.user, systemTags)
-    statsd.gauge('system.cpu.system', cpuUsage.system, systemTags)
+    statsd.gauge('system.cpu.user', cpuUsage.user, 1, systemTags)
+    statsd.gauge('system.cpu.system', cpuUsage.system, 1, systemTags)
 
     // Active sessions
     const sessionTags = [...systemTags, 'metric_type:session'];
-    statsd.gauge('terminal.sessions.active', this.terminalSessionMetrics.size, sessionTags)
+    statsd.gauge('terminal.sessions.active', this.terminalSessionMetrics.size, 1, sessionTags)
 
     // Terminal session health
     let healthySessions = 0
@@ -392,7 +392,7 @@ export class EnhancedDatadogMonitoring {
       }
     }
 
-    statsd.gauge('terminal.sessions.healthy', healthySessions, sessionTags)
+    statsd.gauge('terminal.sessions.healthy', healthySessions, 1, sessionTags)
   }
 
   /**


### PR DESCRIPTION
## Summary

- Fix 28 TypeScript strict mode errors in `src/lib/monitoring/enhanced-datadog-integration.ts`
- All errors were caused by StatsD method calls (increment, gauge, histogram) passing string[] tags as the third argument
- The StatsD type definitions expect the third parameter to be `sampleRate: number`, not tags
- Added explicit sampleRate of 1 (100% sampling) before the tags parameter to match method signatures

## Test plan

- [x] Run `npx tsc --noEmit --strict 2>&1 | grep enhanced-datadog-integration` - returns no errors
- [x] All 28 errors resolved

Generated with Claude Code