### PR TITLE
fix: TypeScript strict mode Recharts Formatter types

### DIFF
--- a/src/components/dashboard/AIUsageWidget.tsx
+++ b/src/components/dashboard/AIUsageWidget.tsx
@@ -177,7 +177,8 @@ function AIUsageWidgetInner({
   }, [data])
 
   // Memoize tooltip formatter to prevent recreation on every render
-  const tooltipFormatter = useCallback((value: number, name: string) => {
+  const tooltipFormatter = useCallback((value: number | undefined, name: string | undefined) => {
+    if (value === undefined) return ''
     if (name === 'cost') return `$${value.toFixed(2)}`
     return value
   }, [])

--- a/src/components/monitoring/MonitoringDashboard.tsx
+++ b/src/components/monitoring/MonitoringDashboard.tsx
@@ -259,7 +259,7 @@ export default function MonitoringDashboard() {
                     <XAxis dataKey="time" fontSize={12} />
                     <YAxis fontSize={12} tickFormatter={formatBytes} />
                     <Tooltip 
-                      formatter={(value: number) => formatBytes(value)}
+                      formatter={(value: number | undefined) => value === undefined ? '' : formatBytes(value)}
                       labelFormatter={(label) => String(label)}
                     />
                     <Legend />


### PR DESCRIPTION
## Summary
- Fixed TypeScript strict mode errors in Recharts Formatter callbacks
- Both files now properly handle undefined value/name parameters

## Changes
- **AIUsageWidget.tsx**: Changed tooltipFormatter to accept undefined parameters with guard clause
- **MonitoringDashboard.tsx**: Added ternary check for undefined value in formatter

## Test plan
- [x] Verified with `npx tsc --noEmit --strict`

🤖 Generated with [Claude Code](https://claude.com/claude-code)