### PR TITLE
Docs: fix 1.4.0 date and boot time metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validation script validate-issue-790-fix.sh for automated testing of the fix
 - Documentation of GAS (Generate-Assess-Synthesize) methodology used to solve Issue #790
 
-## [1.4.0] - 2026-01-XX
+## [1.4.0] - 2026-01-31
 
 ### Added
 - Initial release of unified services VM

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,7 @@ This document outlines the current state, planned features, and long-term vision
 **Stability**: Production-ready with active development
 
 **Key Achievements**:
-- Lightning-fast boot time (26 seconds average)
+- Lightning-fast boot time (~6.5 seconds average)
 - Ultra-compact size (59MB compressed, 175MB uncompressed)
 - Full IDE experience with OpenVSCode Server
 - Integrated Datadog VSCode Extension (v2.0.0)
@@ -47,8 +47,8 @@ This document outlines the current state, planned features, and long-term vision
 
 ### Performance Goals
 
-- [ ] Reduce boot time to <25 seconds average
-- [ ] Improve cold start to <24 seconds
+- [x] Reduce boot time to <25 seconds average (achieved ~6.5s)
+- [x] Improve cold start to <24 seconds (achieved ~6.5s)
 - [ ] Optimize memory usage to 350MB baseline
 - [ ] Further compression to <55MB (if possible)
 


### PR DESCRIPTION
## Summary\n- Fix CHANGELOG 1.4.0 placeholder date\n- Update ROADMAP boot time to ~6.5s and mark goals achieved\n\n## Testing\n- Not run (docs-only changes)