### PR TITLE
chore: stop ignoring vibecode_webgui folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -392,9 +392,6 @@ PROMISE_VERIFICATION_REPORT.md
 # Tauri build artifacts (large)
 src-tauri/target/
 
-# Separate workspace (should not be committed)
-vibecode_webgui/
-
 # Event logs
 .events.jsonl
 .specstory/


### PR DESCRIPTION
Stops ignoring vibecode_webgui/ so tooling can scan GT config and automate polecat dispatch.