### PR TITLE
fix: run bd/gt from Gas Town root

### DIFF
--- a/scripts/dispatch_issues_to_polecats.py
+++ b/scripts/dispatch_issues_to_polecats.py
@@ -2,9 +2,11 @@
 
 import argparse
 import json
+import os
 import subprocess
 import sys
-from typing import Dict, List, Optional, Tuple
+from pathlib import Path
+from typing import Dict, List, Optional
 
 REPO = 'ryanmaclean/vibecode-webgui'
 RIG = 'vibecode_webgui'
@@ -23,6 +25,18 @@ LABEL_TO_POLECAT = {
 
 def run(cmd: List[str], cwd: Optional[str] = None, check: bool = True) -> subprocess.CompletedProcess:
     return subprocess.run(cmd, cwd=cwd, check=check, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+
+def detect_town_root(explicit: Optional[str]) -> str:
+    if explicit:
+        return explicit
+
+    repo_root = Path(__file__).resolve().parents[1]
+    candidate = repo_root / 'vibecode_webgui'
+    if candidate.exists() and candidate.is_dir():
+        return str(candidate)
+
+    return str(repo_root)
 
 
 def gh_issue_list(label: str, limit: int) -> List[Dict]:
@@ -46,16 +60,16 @@ def gh_issue_list(label: str, limit: int) -> List[Dict]:
     return json.loads(proc.stdout)
 
 
-def bd_find_by_external_ref(external_ref: str) -> Optional[str]:
+def bd_find_by_external_ref(external_ref: str, town_root: str) -> Optional[str]:
     # bd list schema in this repo doesn't expose external_ref, so we search by title.
-    proc = run(['bd', 'search', external_ref, '--limit', '5', '--json'], check=True)
+    proc = run(['bd', 'search', external_ref, '--limit', '5', '--json'], cwd=town_root, check=True)
     items = json.loads(proc.stdout)
     if not items:
         return None
     return items[0].get('id')
 
 
-def bd_create_for_github_issue(issue: Dict) -> str:
+def bd_create_for_github_issue(issue: Dict, town_root: str) -> str:
     issue_num = issue['number']
     external_ref = f'gh-{issue_num}'
     title = f'[{external_ref}] {issue["title"]}'
@@ -72,6 +86,7 @@ def bd_create_for_github_issue(issue: Dict) -> str:
             '--description',
             description,
         ],
+        cwd=town_root,
         check=True,
     )
 
@@ -79,18 +94,18 @@ def bd_create_for_github_issue(issue: Dict) -> str:
     if created_id:
         return created_id
 
-    found = bd_find_by_external_ref(external_ref)
+    found = bd_find_by_external_ref(external_ref, town_root)
     if not found:
         raise RuntimeError(f'Created issue but could not resolve bead id for {external_ref}')
     return found
 
 
-def gt_sling(bead_id: str, target: str, message: str, dry_run: bool) -> None:
+def gt_sling(bead_id: str, target: str, message: str, dry_run: bool, town_root: str) -> None:
     cmd = ['gt', 'sling']
     if dry_run:
         cmd.append('--dry-run')
     cmd += [bead_id, target, '-m', message]
-    proc = run(cmd, check=False)
+    proc = run(cmd, cwd=town_root, check=False)
     if proc.returncode != 0:
         raise RuntimeError(proc.stderr.strip() or proc.stdout.strip())
 
@@ -100,7 +115,10 @@ def main() -> int:
     parser.add_argument('--label', action='append', default=[], help='GitHub label to dispatch (repeatable).')
     parser.add_argument('--limit', type=int, default=50)
     parser.add_argument('--dry-run', action='store_true')
+    parser.add_argument('--town-root', default=None, help='Path to Gas Town town-root (defaults to ./vibecode_webgui if present).')
     args = parser.parse_args()
+
+    town_root = detect_town_root(args.town_root)
 
     labels = args.label or list(LABEL_TO_POLECAT.keys())
 
@@ -116,20 +134,20 @@ def main() -> int:
             issue_num = issue['number']
             external_ref = f'gh-{issue_num}'
 
-            bead_id = bd_find_by_external_ref(external_ref)
+            bead_id = bd_find_by_external_ref(external_ref, town_root)
             if not bead_id and args.dry_run:
                 print(f'• {external_ref} -> (would create bd issue) -> {target}')
                 continue
 
             if not bead_id:
-                bead_id = bd_create_for_github_issue(issue)
+                bead_id = bd_create_for_github_issue(issue, town_root)
 
             msg = f'Dispatch {external_ref}: {issue["title"]}'
             if args.dry_run:
                 print(f'• {external_ref} -> {bead_id} -> {target} (dry-run)')
                 continue
 
-            gt_sling(bead_id, target, msg, args.dry_run)
+            gt_sling(bead_id, target, msg, args.dry_run, town_root)
             dispatched += 1
             print(f'✓ {external_ref} -> {bead_id} -> {target}')
 


### PR DESCRIPTION
Ensures scripts/dispatch_issues_to_polecats.py runs Issues chained together like beads. A lightweight issue tracker with first-class dependency support.

Usage:
  bd [flags]
  bd [command]

Maintenance:
  rename-prefix      Rename the issue prefix for all issues in the database
  repair             Repair corrupted database by cleaning orphaned references
  resolve-conflicts  Resolve git merge conflicts in JSONL files

Integrations & Advanced:
Working With Issues:
  close              Close one or more issues
  comments           View or manage comments on an issue
  create             Create a new issue (or multiple issues from markdown file)
  create-form        Create a new issue using an interactive form
  delete             Delete one or more issues and clean up references
  edit               Edit an issue field in $EDITOR
  gate               Manage async coordination gates
  label              Manage issue labels
  list               List issues
  merge-slot         Manage merge-slot gates for serialized conflict resolution
  move               Move an issue to a different rig with dependency remapping
  q                  Quick capture: create issue and output only ID
  refile             Move an issue to a different rig
  reopen             Reopen one or more closed issues
  search             Search issues by text query
  set-state          Set operational state (creates event + updates label)
  show               Show issue details
  state              Query the current value of a state dimension
  update             Update one or more issues

Views & Reports:
  activity           Show real-time molecule state feed
  count              Count issues matching filters
  diff               Show changes between two commits or branches (requires Dolt backend)
  history            Show version history for an issue (requires Dolt backend)
  lint               Check issues for missing template sections
  stale              Show stale issues (not updated recently)
  status             Show issue database overview and statistics
  types              List valid issue types

Dependencies & Structure:
  dep                Manage dependencies
  duplicate          Mark an issue as a duplicate of another
  duplicates         Find and optionally merge duplicate issues
  epic               Epic management commands
  graph              Display issue dependency graph
  supersede          Mark an issue as superseded by a newer one
  swarm              Swarm management for structured epics

Sync & Data:
  branch             List or create branches (requires Dolt backend)
  daemon             Manage background sync daemon
  export             Export issues to JSONL or Obsidian format
  import             Import issues from JSONL format
  merge              Git merge driver for beads JSONL files
  restore            Restore full history of a compacted issue from git
  sync               Export database to JSONL (sync with git)
  vc                 Version control operations (requires Dolt backend)

Setup & Configuration:
  config             Manage configuration settings
  hooks              Manage git hooks for bd auto-sync
  human              Show essential commands for human users
  info               Show database and daemon information
  init               Initialize bd in the current directory
  onboard            Display minimal snippet for AGENTS.md
  prime              Output AI-optimized workflow context
  quickstart         Quick start guide for bd
  setup              Setup integration with AI editors
  where              Show active beads location

Maintenance:
  doctor             Check and fix beads installation health (start here)
  migrate            Database migration commands
  preflight          Show PR readiness checklist
  upgrade            Check and manage bd version upgrades
  worktree           Manage git worktrees for parallel development

Integrations & Advanced:
  admin              Administrative commands for database maintenance
  jira               Jira integration commands
  linear             Linear integration commands
  repo               Manage multiple repository configuration

Additional Commands:
  agent              Manage agent bead state
  audit              Record and label agent interactions (append-only JSONL)
  blocked            Show blocked issues
  completion         Generate the autocompletion script for the specified shell
  cook               Compile a formula into a proto (ephemeral by default)
  defer              Defer one or more issues for later
  formula            Manage workflow formulas
  help               Help about any command
  hook               Execute a git hook (called by hook scripts)
  mail               Delegate to mail provider (e.g., gt mail)
  mol                Molecule commands (work templates)
  orphans            Identify orphaned issues (referenced in commits but still open)
  ready              Show ready work (no blockers, open or in_progress)
  ship               Publish a capability for cross-project dependencies
  slot               Manage agent bead slots
  undefer            Undefer one or more issues (restore to open)
  version            Print version information

Flags:
      --actor string            Actor name for audit trail (default: $BD_ACTOR, git user.name, $USER)
      --allow-stale             Allow operations on potentially stale data (skip staleness check)
      --db string               Database path (default: auto-discover .beads/*.db)
  -h, --help                    help for bd
      --json                    Output in JSON format
      --lock-timeout duration   SQLite busy timeout (0 = fail immediately if locked) (default 30s)
      --no-auto-flush           Disable automatic JSONL sync after CRUD operations
      --no-auto-import          Disable automatic JSONL import when newer than DB
      --no-daemon               Force direct storage mode, bypass daemon if running
      --no-db                   Use no-db mode: load from JSONL, no SQLite
      --profile                 Generate CPU profile for performance analysis
  -q, --quiet                   Suppress non-essential output (errors only)
      --readonly                Read-only mode: block write operations (for worker sandboxes)
      --sandbox                 Sandbox mode: disables daemon and auto-sync
  -v, --verbose                 Enable verbose/debug output
  -V, --version                 Print version information

Use "bd [command] --help" for more information about a command. + Gas Town (gt) manages multi-agent workspaces called rigs.

It coordinates agent spawning, work distribution, and communication
across distributed teams of AI agents working on shared codebases.

Usage:
  gt [command]

Work Management:
  bead        Bead management utilities
  cat         Display bead content
  close       Close one or more beads
  commit      Git commit with automatic agent identity
  convoy      Track batches of work across rigs
  done        Signal work ready for merge queue
  formula     Manage workflow formulas
  gate        Gate coordination commands
  handoff     Hand off to a fresh session, work continues from hook
  hook        Show or attach work on your hook
  mol         Agent molecule workflow commands
  mq          Merge queue operations
  orphans     Find lost polecat work
  park        Park work on a gate for async resumption
  ready       Show work ready across town
  release     Release stuck in_progress issues back to pending
  resume      Resume from parked work or check for handoff messages
  show        Show details of a bead
  sling       Assign work to an agent (THE unified work dispatch command)
  synthesis   Manage convoy synthesis steps
  trail       Show recent agent activity
  unsling     Remove work from an agent's hook

Agent Management:
  agents      Switch between Gas Town agent sessions
  boot        Manage Boot (Deacon watchdog)
  callbacks   Handle agent callbacks
  deacon      Manage the Deacon (town-level watchdog)
  dog         Manage dogs (cross-rig infrastructure workers)
  mayor       Manage the Mayor (Chief of Staff for cross-rig coordination)
  polecat     Manage polecats (ephemeral workers, one task then nuked)
  refinery    Manage the Refinery (merge queue processor)
  role        Show or manage agent role
  session     Manage polecat sessions
  witness     Manage the Witness (per-rig polecat health monitor)

Communication:
  broadcast   Send a nudge message to all workers
  dnd         Toggle Do Not Disturb mode for notifications
  escalate    Escalation system for critical issues
  mail        Agent messaging system
  notify      Set notification level
  nudge       Send a synchronous message to any Gas Town worker
  peek        View recent output from a polecat or crew session

Services:
  daemon      Manage the Gas Town daemon
  down        Stop all Gas Town services
  shutdown    Shutdown Gas Town with cleanup
  start       Start Gas Town or a crew workspace
  up          Bring up all Gas Town services

Workspace:
  crew        Manage crew workers (persistent workspaces for humans)
  git-init    Initialize git repository for a Gas Town HQ
  init        Initialize current directory as a Gas Town rig
  install     Create a new Gas Town HQ (workspace)
  namepool    Manage polecat name pools
  rig         Manage rigs in the workspace
  worktree    Create worktree in another rig for cross-rig work

Configuration:
  account     Manage Claude Code accounts
  completion  Generate the autocompletion script for the specified shell
  config      Manage Gas Town configuration
  disable     Disable Gas Town system-wide
  enable      Enable Gas Town system-wide
  hooks       List all Claude Code hooks in the workspace
  issue       Manage current issue for status line display
  plugin      Plugin management
  shell       Manage shell integration
  theme       View or set tmux theme for the current rig
  uninstall   Remove Gas Town from the system

Diagnostics:
  activity    Emit and view activity events
  audit       Query work history by actor
  checkpoint  Manage session checkpoints for crash recovery
  costs       Show costs for running Claude sessions [DISABLED]
  dashboard   Start the convoy tracking web dashboard
  doctor      Run health checks on the workspace
  feed        Show real-time activity feed from beads and gt events
  help        Help about any command
  info        Show Gas Town information and what's new
  log         View town activity log
  patrol      Patrol digest management
  prime       Output role context for current directory
  seance      Talk to your predecessor sessions
  stale       Check if the gt binary is stale
  status      Show overall town status
  thanks      Thank the human contributors to Gas Town
  version     Print version information
  whoami      Show current identity for mail commands

Additional Commands:
  cycle       Cycle between sessions in the same group
  tap         Claude Code hook handlers
  town        Town-level operations

Flags:
  -h, --help      help for gt
  -v, --version   version for gt

Use "gt [command] --help" for more information about a command. in the Gas Town town-root (./vibecode_webgui) so created beads exist where  expects them.