### PR TITLE
chore: add auto-claude entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -497,3 +497,14 @@ PROMISE_VERIFICATION_REPORT.md
 
 # Event logs
 .events.jsonl
+
+# Auto Claude data directory
+.auto-claude/
+
+# Auto Claude generated files
+.auto-claude-security.json
+.auto-claude-status
+.claude_settings.json
+.worktrees/
+.security-key
+logs/security/


### PR DESCRIPTION
## Summary
- Adds auto-claude entries to .gitignore to exclude temporary spec and worktree files

## Test plan
- [x] Verified .gitignore entries are correct
- [x] No unintended files affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to exclude Auto Claude generated artifacts and temporary files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->