### PR TITLE
security: hard-pin python template deps and patch backup fast-xml-parser

### DIFF
--- a/backups/security-patch-20260214_160432/package-lock.json
+++ b/backups/security-patch-20260214_160432/package-lock.json
@@ -20083,9 +20083,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz",
-      "integrity": "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.7.tgz",
+      "integrity": "sha512-JzVLro9NQv92pOM/jTCR6mHlJh2FGwtomH8ZQjhFj/R29P2Fnj38OgPJVtcvYw6SuKClhgYuwUZf5b3rd8u2mA==",
       "funding": [
         {
           "type": "github",
@@ -20094,7 +20094,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.0"
+        "strnum": "^2.1.2"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"

--- a/backups/security-patch-20260214_160432/package.json
+++ b/backups/security-patch-20260214_160432/package.json
@@ -261,7 +261,7 @@
     "axios": "^1.13.4",
     "diff": "8.0.3",
     "hono": "^4.11.4",
-    "fast-xml-parser": "^5.3.4"
+    "fast-xml-parser": "^5.3.6"
   },
   "devDependencies": {
     "@axe-core/playwright": "4.11.1",

--- a/config/templates/python/azure-pytorch-dsvm/requirements.txt
+++ b/config/templates/python/azure-pytorch-dsvm/requirements.txt
@@ -23,4 +23,4 @@ accelerate
 tqdm
 
 # Security: Pin urllib3 to address CVE vulnerabilities
-urllib3>=2.6.3
+urllib3==2.6.3

--- a/config/templates/python/basic-gradio-app/requirements.txt
+++ b/config/templates/python/basic-gradio-app/requirements.txt
@@ -1,2 +1,2 @@
 gradio
-python-multipart>=0.0.22
+python-multipart==0.0.22

--- a/config/templates/python/huggingface-inference-app/requirements.txt
+++ b/config/templates/python/huggingface-inference-app/requirements.txt
@@ -5,4 +5,4 @@ huggingface_hub
 accelerate
 
 # Security: Pin urllib3 to address CVE vulnerabilities
-urllib3>=2.6.3
+urllib3==2.6.3

--- a/config/templates/python/semantic-kernel-rag-app/requirements.txt
+++ b/config/templates/python/semantic-kernel-rag-app/requirements.txt
@@ -1,12 +1,12 @@
-semantic-kernel>=1.39.4
+semantic-kernel==1.39.4
 python-dotenv
 GitPython
 chromadb
 markdown
 beautifulsoup4
-azure-core>=1.38.0
-pyasn1>=0.6.2
+azure-core==1.38.0
+pyasn1==0.6.2
 
 # Security: Pin urllib3 and Werkzeug to address CVE vulnerabilities
-urllib3>=2.6.3
-Werkzeug>=3.1.5
+urllib3==2.6.3
+Werkzeug==3.1.5

--- a/config/templates/python/zenml-basic-pipeline/requirements.txt
+++ b/config/templates/python/zenml-basic-pipeline/requirements.txt
@@ -6,6 +6,6 @@ scikit-learn
 numpy
 
 # Security: Pin urllib3 to address CVE vulnerabilities
-urllib3>=2.6.3
-python-multipart>=0.0.22
-starlette>=0.49.1
+urllib3==2.6.3
+python-multipart==0.0.22
+starlette==0.49.1

--- a/examples/pydantic-ai-cli-agent/requirements.txt
+++ b/examples/pydantic-ai-cli-agent/requirements.txt
@@ -33,6 +33,6 @@ opentelemetry-api>=1.20.0
 opentelemetry-sdk>=1.20.0
 
 # Security: Pin urllib3 to address CVE vulnerabilities
-urllib3>=2.6.3
-python-multipart>=0.0.22
-pyasn1>=0.6.2
+urllib3==2.6.3
+python-multipart==0.0.22
+pyasn1==0.6.2


### PR DESCRIPTION
## Summary
- hard-pin vulnerable python dependencies in template/example requirement files
- update backup lockfile override and regenerate lockfile-only to move fast-xml-parser to 5.3.7

## Safety
- lockfile-only update for backup path with --ignore-scripts
- no file deletions