### PR TITLE
ci: bump workflow node baseline to 20.19.0 for prisma 7

### DIFF
--- a/.github/workflows/ci-simplified.yml
+++ b/.github/workflows/ci-simplified.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: '20.11.0'  # Match package.json engines requirement
+  NODE_VERSION: '20.19.0'  # Match current package engine requirements
   DD_SERVICE: ${{ github.event.repository.name }}
   DD_ENV: ci
   DD_VERSION: ${{ github.sha }}

--- a/.github/workflows/main-branch-ci.yml
+++ b/.github/workflows/main-branch-ci.yml
@@ -16,7 +16,7 @@ permissions:
   security-events: write
 
 env:
-  NODE_VERSION: '20.11.0'
+  NODE_VERSION: '20.19.0'
   DD_SERVICE: ${{ github.event.repository.name }}
   DD_ENV: ci
   DD_VERSION: ${{ github.sha }}

--- a/.github/workflows/release-branch-ci.yml
+++ b/.github/workflows/release-branch-ci.yml
@@ -16,7 +16,7 @@ permissions:
   deployments: write
 
 env:
-  NODE_VERSION: '20.11.0'
+  NODE_VERSION: '20.19.0'
   DD_SERVICE: ${{ github.event.repository.name }}
   DD_ENV: ci
   DD_VERSION: ${{ github.sha }}

--- a/.github/workflows/shared-setup.yml
+++ b/.github/workflows/shared-setup.yml
@@ -9,7 +9,7 @@ on:
         description: 'Node.js version to use'
         required: false
         type: string
-        default: '20.11.0'
+        default: '20.19.0'
       cache-dependency-path:
         description: 'Path to package-lock.json for cache key'
         required: false


### PR DESCRIPTION
Fixes failing quick-validation install step on main by updating workflow Node baseline from 20.11.0 to 20.19.0 (Prisma 7 requirement).