### PR TITLE
Recovery: land PR #1987 AppleVF fast-boot assets on latest main

### DIFF
--- a/docs/virtualization/openvscode-microvm.md
+++ b/docs/virtualization/openvscode-microvm.md
@@ -38,13 +38,11 @@ npm run microvm:https   # -> proxies https://127.0.0.1:3443 to the microVM
 
 ### arm64 guest
 ```bash
-# Build or copy the Apple VF artifacts into bench-images/apple-vf/
-# (run these from the `kernel-builder` Lima VM or a Debian container)
-lima kernel-builder -- ./scripts/benchmarks/build-minivim-kernel.sh arm64 6.12.10
-lima kernel-builder -- ./scripts/benchmarks/build-busybox-musl.sh arm64
-# (optional) assemble initramfs
-cd bench-images/apple-vf
-find rootfs -print0 | cpio --null -ov --format=newc | gzip -9 > openvscode-initramfs.cpio.gz
+# Build Apple VF fast-boot assets (run from the `kernel-builder` Lima VM or a Debian container)
+./scripts/benchmarks/build-applevf-fastboot-assets.sh arm64 6.12.10
+
+# (Optional) rebuild an OpenVSCode initramfs for arm64
+./scripts/build-fast-openvscode-vm-with-ai-tools.sh
 
 # Launch via QEMU
 MICROVM_ARCH=arm64 MICROVM_RUNTIME=qemu scripts/benchmarks/vscode_microvm.sh start
@@ -86,7 +84,7 @@ captures console output in `${TARGET_DIR}/qemu-console.log` for debugging.
 
 ```
 $ scripts/benchmarks/vscode_microvm.sh measure 5
-{"port_ready_ms": [6212, 6002, 6103, 6057, 6177]}
+{"port_ready_ms": [6212, 6002, 6103, 6057, 6177], "healthz_ready_ms": [6212, 6002, 6103, 6057, 6177]}
 
 $ MICROVM_ARCH=arm64 scripts/benchmarks/vscode_microvm.sh measure 3
 {"port_ready_ms": [19745, 19525, 19217]}
@@ -98,6 +96,20 @@ we still trail containers for cold launches; keep a warm VM running for demos to
 avoid repeated cold boots. Once we validate on Apple Silicon with Virtualization
 Framework passthrough we expect the arm64 numbers to drop substantially.
 
+### Apple VF fast-boot (arm64)
+
+Run the dedicated benchmark (EFI-stub kernel + minimal BusyBox initramfs):
+```bash
+APPLEVF_KERNEL=bench-images/apple-vf-fastboot/vmlinux-efi-stub \
+APPLEVF_INITRD=bench-images/apple-vf-fastboot/initramfs-minimal.cpio.gz \
+scripts/benchmarks/applevf_fastboot_bench.sh bench 5
+```
+
+| Runtime | Kernel | Initramfs | Avg /healthz (ms) | Notes |
+| --- | --- | --- | --- | --- |
+| Apple VF (vfkit) | vmlinux-efi-stub | initramfs-minimal | TBD | Run on M-series + record results |
+| QEMU (arm64 virt) | vmlinux-fast | openvscode-initramfs | ~19,500 | Intel host, TCG |
+
 ## Packaging
 ```bash
 # x86_64 bundle
@@ -105,6 +117,9 @@ scripts/release/package-fast-openvscode-vm.sh fast-openvscode-vm
 
 # arm64 bundle
 scripts/release/package-fast-openvscode-vm.sh fast-openvscode-vm-arm64
+
+# Apple VF fast-boot assets bundle
+scripts/release/package-fast-openvscode-vm.sh bench-images/apple-vf-fastboot
 ```
 Artifacts land in `dist/` with matching `.sha256` files. The script excludes
 cached tarballs, QEMU logs, and pid files so uploads stay lean. To refresh the

--- a/scripts/benchmarks/build-applevf-fastboot-assets.sh
+++ b/scripts/benchmarks/build-applevf-fastboot-assets.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Build arm64 EFI-stub kernel + minimal BusyBox initramfs for Apple VF fast boot
+set -euo pipefail
+
+ARCH=${1:-arm64}
+KERNEL_VERSION=${2:-6.12.10}
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+OUTPUT_DIR="${ROOT_DIR}/bench-images/apple-vf-fastboot"
+
+if [[ "$ARCH" != "arm64" ]]; then
+  echo "error: Apple VF fast-boot assets require arm64" >&2
+  exit 1
+fi
+
+echo "=== Apple VF Fast-Boot Assets ==="
+echo "Architecture: ${ARCH}"
+echo "Kernel version: ${KERNEL_VERSION}"
+echo "Output: ${OUTPUT_DIR}"
+echo ""
+
+"${ROOT_DIR}/scripts/benchmarks/build-efi-stub-kernel.sh" "$ARCH" "$KERNEL_VERSION"
+"${ROOT_DIR}/scripts/benchmarks/build-minimal-initramfs.sh" "$ARCH"
+
+echo ""
+echo "Assets ready:"
+echo "  - ${OUTPUT_DIR}/vmlinux-efi-stub"
+echo "  - ${OUTPUT_DIR}/initramfs-minimal.cpio.gz"
+echo ""
+echo "Next:"
+echo "  APPLEVF_KERNEL=${OUTPUT_DIR}/vmlinux-efi-stub \\"
+echo "  APPLEVF_INITRD=${OUTPUT_DIR}/initramfs-minimal.cpio.gz \\"
+echo "  scripts/benchmarks/applevf_fastboot_bench.sh bench 5"

--- a/scripts/benchmarks/vscode_microvm.sh
+++ b/scripts/benchmarks/vscode_microvm.sh
@@ -83,6 +83,7 @@ PID_FILE="$VM_DIR/.microvm.pid"
 SERIAL_LOG="$VM_DIR/qemu-console.log"
 COMMON_OPTS=("-kernel" "$KERNEL" "-initrd" "$INITRD" "-append" "$APPEND" "-display" "none")
 LAST_READY_MS=0
+LAST_HEALTHZ_MS=0
 READY_TIMEOUT=${MICROVM_READY_TIMEOUT:-60}
 READY_POLL_INTERVAL=${MICROVM_READY_POLL_SEC:-0.1}
 
@@ -178,6 +179,12 @@ start_vm() {
   fi
   require_vm_assets
   rm -f "$SERIAL_LOG"
+  if [[ "$ARCH" == "arm64" && ("$RUNTIME" == "applevf" || "$RUNTIME" == "vf") ]]; then
+    APPEND="console=hvc0 rdinit=/init quiet"
+    if [[ -n ${MICROVM_CMDLINE_EXTRA:-} ]]; then
+      APPEND+=" ${MICROVM_CMDLINE_EXTRA}"
+    fi
+  fi
   case "$RUNTIME" in
     qemu)
       start_qemu
@@ -197,6 +204,8 @@ start_vm() {
     exit 1
   }
   LAST_READY_MS=$elapsed
+  LAST_HEALTHZ_MS=$elapsed
+  echo "$elapsed" > "${VM_DIR}/healthz-ready-ms"
   echo "microVM started (pid $(cat "$PID_FILE"), ready ${elapsed}ms)"
 }
 
@@ -240,6 +249,7 @@ measure_latency() {
   for _ in $(seq 1 "$iterations"); do
     stop_vm >/dev/null 2>&1 || true
     LAST_READY_MS=0
+    LAST_HEALTHZ_MS=0
     start_vm >/dev/null
     if [[ ${LAST_READY_MS:-0} -eq 0 ]]; then
       echo "error: failed to capture readiness metric" >&2
@@ -249,6 +259,15 @@ measure_latency() {
   done
   printf '{"port_ready_ms": ['
   local first=1
+  for sample in "${samples[@]}"; do
+    if [[ $first -eq 0 ]]; then
+      printf ', '
+    fi
+    printf '%s' "$sample"
+    first=0
+  done
+  printf '], "healthz_ready_ms": ['
+  first=1
   for sample in "${samples[@]}"; do
     if [[ $first -eq 0 ]]; then
       printf ', '

--- a/scripts/release/package-fast-openvscode-vm.sh
+++ b/scripts/release/package-fast-openvscode-vm.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+TARGET_DIR=${1:-fast-openvscode-vm}
+VM_DIR="$ROOT_DIR/$TARGET_DIR"
+DIST_DIR="$ROOT_DIR/dist"
+TIMESTAMP=$(date -u +%Y%m%dT%H%M%SZ)
+OUTPUT_NAME="${TARGET_DIR//\//-}"
+OUTPUT="$DIST_DIR/${OUTPUT_NAME}-$TIMESTAMP.tar.gz"
+SHA_OUTPUT="$OUTPUT.sha256"
+EXCLUDES=(
+  "--exclude=${TARGET_DIR}/downloads/*.tar.gz"
+  "--exclude=${TARGET_DIR}/downloads/*.zip"
+  "--exclude=${TARGET_DIR}/openvscode-initramfs.cpio.gz.bak"
+  "--exclude=${TARGET_DIR}/qemu.log"
+  "--exclude=${TARGET_DIR}/qemu-console.log"
+  "--exclude=${TARGET_DIR}/qemu-test.log"
+  "--exclude=${TARGET_DIR}/.microvm.pid"
+)
+
+if [[ ! -d "$VM_DIR" ]]; then
+  echo "error: fast-openvscode-vm directory not found" >&2
+  exit 1
+fi
+
+mkdir -p "$DIST_DIR"
+
+echo "Packaging ${TARGET_DIR} into $OUTPUT"
+
+tar -C "$ROOT_DIR" -czf "$OUTPUT" "${EXCLUDES[@]}" "$TARGET_DIR"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum "$OUTPUT" > "$SHA_OUTPUT"
+else
+  shasum -a 256 "$OUTPUT" > "$SHA_OUTPUT"
+fi
+
+echo "Created archive: $OUTPUT"
+echo "SHA256:"
+cat "$SHA_OUTPUT"


### PR DESCRIPTION
## Summary
- replay PR #1987 changes on top of current `main`
- resolve merge conflicts in `scripts/benchmarks/vscode_microvm.sh` by preserving current applevf launcher/env behavior
- carry forward AppleVF fast-boot asset build script and packaging/docs updates

## Why
Original PR #1987 became conflicting after recent mainline changes. This replacement cleanly lands the same feature set with minimal conflict-only adjustments.
